### PR TITLE
Feat: Add Plasma Heading and use Plasma and Kirigami components

### DIFF
--- a/package/contents/ui/CompactRepresentation.qml
+++ b/package/contents/ui/CompactRepresentation.qml
@@ -1,0 +1,27 @@
+import QtQuick 2.3
+import QtQuick.Layouts 1.0
+import QtQuick.Controls 2.0
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.plasmoid 2.0
+
+Item {
+    anchors.fill: parent
+    
+    PlasmaCore.SvgItem {
+        anchors.centerIn: parent
+        width: parent.width < parent.height ? parent.width : parent.height
+        height: width
+
+        svg: PlasmaCore.Svg {
+            imagePath: Qt.resolvedUrl("assets/logo.svg");
+        }
+
+        MouseArea {
+            anchors.fill: parent
+
+            onClicked: {
+                plasmoid.expanded = !plasmoid.expanded
+            }
+        }
+    }
+}

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -15,33 +15,12 @@ import org.kde.kirigami 2.19 as Kirigami
 import QtWebEngine 1.9
 
 Item {
-	id:root
+	id: root
 	property bool themeMismatch: false;
 	property int nextReloadTime: 0
 	property int reloadRetries: 0
 
-	// Plasmoid.backgroundHints: plasmoid.configuration.showBackground ? PlasmaCore.Types.DefaultBackground : PlasmaCore.Types.NoBackground
-	Plasmoid.compactRepresentation: Item {
-		anchors.fill:parent
-		
-		PlasmaCore.SvgItem {
-			anchors.centerIn: parent
-			width: parent.width < parent.height ? parent.width : parent.height
-			height: width
-
-			svg: PlasmaCore.Svg {
-				imagePath:Qt.resolvedUrl("assets/logo.svg");
-			}
-
-			MouseArea {
-				anchors.fill: parent
-
-				onClicked: {
-					plasmoid.expanded = !plasmoid.expanded
-				}
-			}
-		}
-	}
+	Plasmoid.compactRepresentation: CompactRepresentation {}
 
 	Plasmoid.fullRepresentation: ColumnLayout {
 		anchors.fill: parent
@@ -53,11 +32,12 @@ Item {
 
 		//-----------------------------  Helpers ------------------
 		// Added workaround by @zontafil thank you!
+		
 		Timer {
-			id:exposeTimer
+			id: exposeTimer
 
-			interval:plasmoid.configuration.focusInterval ? plasmoid.configuration.focusInterval : 0
-			running:false
+			interval: plasmoid.configuration.focusInterval ? plasmoid.configuration.focusInterval : 0
+			running: false
 			onTriggered: {
 				gptWebView.forceActiveFocus();
 				gptWebView.focus=true;
@@ -67,7 +47,7 @@ Item {
 		}
 
 		Connections {
-			target:plasmoid
+			target: plasmoid
 			function onActivated() {
 				console.log("Plasmoid revealed to user")
 			}
@@ -96,7 +76,6 @@ Item {
 		//------------------------------------- UI -----------------------------------------
 
 		ColumnLayout {
-			height: 24 * PlasmaCore.Units.devicePixelRatio
 			spacing: Kirigami.Units.mediumSpacing
 
 			PlasmaExtras.PlasmoidHeading {
@@ -219,6 +198,7 @@ Item {
 			}
 
 			//-------------------- Connections  -----------------------
+
 			Binding {
 				target: plasmoid
 				property: "hideOnWindowDeactivate"
@@ -302,85 +282,7 @@ Item {
 				}
 			}
 		}
-
-		// WebEngineView {
-		// 	Layout.fillWidth: true
-		// 	Layout.alignment: Qt.AlignBottom
-			
-		// 	id: gptWebViewInspector
-		// 	enabled: false
-		// 	visible: false
-		// 	z: 100
-		// 	height: parent.height /2
-		// 	inspectedView: enabled ? gptWebView : null
-		// }
-
-		// Row {
-		// 	id:proLinkContainer
-		// 	Layout.fillWidth:true
-		// 	visible:false;
-		// 	TextField {
-		// 		id:proLinkField
-
-		// 		enabled: proLinkContainer.visible
-		// 		Layout.fillWidth:true
-
-		// 		placeholderText:i18n("Paste the accesss link that was send to your email.")
-		// 		text:""
-		// 	}
-		// 	Button {
-		// 		// text: i18n("ChatGPT Pro")
-		// 		enabled: proLinkContainer.visible
-		// 		icon.name: "go-next"
-		// 		onClicked:  {
-		// 			gptWebView.url = proLinkField.text;
-		// 			proLinkContainer.visible= false;
-		// 		}
-		// 	}
-		// }
-
-		// Row {
-		// 	id:toolRow
-		// 	Layout.alignment:Qt.AlignBottom
-		// 	height:24 * PlasmaCore.Units.devicePixelRatio
-		// 	spacing: 5 *  PlasmaCore.Units.devicePixelRatio
-
-		// 	// Button {
-		// 	// 	text: i18n("Im a Pro")
-		// 	// 	visible:gptWebView.url.toString().match(/chat\.openai\.com\/auth/);
-		// 	// 	icon.name: "x-office-contact"
-		// 	// 	onClicked: proLinkContainer.visible = true;
-		// 	// }
-
-		// 	Button {
-		// 		text: i18n("Back to ChatGPT")
-		// 		visible:!gptWebView.url.toString().match(/chat\.openai\.com\/(|chat|auth)/);
-		// 		enabled:visible
-		// 		icon.name: "edit-undo"
-		// 		onClicked: gptWebView.url = "https://chat.openai.com/chat";
-		// 	}
-			
-		// 	// Button {
-		// 	// 	text: i18n("Debug")
-		// 	// 	visible: Qt.application.arguments[0] == "plasmoidviewer" || plasmoid.configuration.debugConsole
-		// 	// 	enabled:visible
-		// 	// 	icon.name: "view-refresh"
-		// 	// 	onClicked: {
-		// 	// 		gptWebViewInspector.visible = !gptWebViewInspector.visible;
-		// 	// 		gptWebViewInspector.enabled = visible || gptWebViewInspector.visible
-		// 	// 	}
-		// 	// }
-
-		// 	// Button {
-		// 	//     text: i18n("Speek to me")
-		// 	//     icon.name:"microphone-sensitivity-high"
-		// 	//      onClicked: {
-		// 	//          console.log(chatGptProfile.persistentStoragePath)
-		// 	//      }
-		// 	// }
-		// }
 	}
-
 }
 
 

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -7,12 +7,12 @@ import QtQuick 2.3
 import QtQuick.Layouts 1.0
 import QtQuick.Controls 2.0
 import org.kde.plasma.core 2.0 as PlasmaCore
-import org.kde.plasma.components 2.0 as PlasmaComponents
+import org.kde.plasma.components 3.0 as PlasmaComponents
 import org.kde.plasma.plasmoid 2.0
+import org.kde.plasma.extras 2.0 as PlasmaExtras
+import org.kde.kirigami 2.19 as Kirigami
 
 import QtWebEngine 1.9
-// import QtWebEngineCore 1.15
-// import QtWebChannel 1.0
 
 Item {
 	id:root
@@ -23,29 +23,33 @@ Item {
 	// Plasmoid.backgroundHints: plasmoid.configuration.showBackground ? PlasmaCore.Types.DefaultBackground : PlasmaCore.Types.NoBackground
 	Plasmoid.compactRepresentation: Item {
 		anchors.fill:parent
+		
 		PlasmaCore.SvgItem {
-			anchors.centerIn : parent
-			width:parent.width < parent.height ? parent.width : parent.height
-			height:width
+			anchors.centerIn: parent
+			width: parent.width < parent.height ? parent.width : parent.height
+			height: width
 
-			svg : PlasmaCore.Svg {
+			svg: PlasmaCore.Svg {
 				imagePath:Qt.resolvedUrl("assets/logo.svg");
 			}
 
 			MouseArea {
-				anchors.fill:parent
+				anchors.fill: parent
+
 				onClicked: {
 					plasmoid.expanded = !plasmoid.expanded
 				}
 			}
 		}
 	}
-	Plasmoid.fullRepresentation: ColumnLayout {
-		Layout.minimumWidth: 256 * PlasmaCore.Units.devicePixelRatio
-		Layout.minimumHeight:  512 * PlasmaCore.Units.devicePixelRatio
-		Layout.preferredWidth: 480 * PlasmaCore.Units.devicePixelRatio
-		Layout.preferredHeight: 920 * PlasmaCore.Units.devicePixelRatio
 
+	Plasmoid.fullRepresentation: ColumnLayout {
+		anchors.fill: parent
+
+		Layout.minimumWidth: 480 * PlasmaCore.Units.devicePixelRatio
+		Layout.minimumHeight:  720 * PlasmaCore.Units.devicePixelRatio
+		Layout.preferredWidth: 520 * PlasmaCore.Units.devicePixelRatio
+		Layout.preferredHeight: 840 * PlasmaCore.Units.devicePixelRatio
 
 		//-----------------------------  Helpers ------------------
 		// Added workaround by @zontafil thank you!
@@ -91,53 +95,129 @@ Item {
 
 		//------------------------------------- UI -----------------------------------------
 
-		anchors.fill: parent
-		Column {
-			anchors {
-				right:parent.right;
-				left: parent.left;
-				top:parent.top;
-			}
+		ColumnLayout {
 			height: 24 * PlasmaCore.Units.devicePixelRatio
-			spacing: 2 * PlasmaCore.Units.devicePixelRatio
-			Row {
-				anchors {
-					right:pinButton.left;
-					left: parent.left;
-					top:parent.top;
-					bottom:parent.bottom
-				}
-				spacing: 2 * PlasmaCore.Units.devicePixelRatio
-				PlasmaCore.SvgItem {
-					height:parent.height
-					width:height
-					svg: PlasmaCore.Svg {
-						imagePath:Qt.resolvedUrl("./assets/logo.svg");
+			spacing: Kirigami.Units.mediumSpacing
+
+			PlasmaExtras.PlasmoidHeading {
+				Layout.fillWidth: true
+
+				ColumnLayout {					
+					anchors.fill: parent
+					Layout.fillWidth: true
+
+					RowLayout {
+						Layout.fillWidth: true
+
+						RowLayout {
+							Layout.fillWidth: true
+							spacing: Kirigami.Units.mediumSpacing
+
+							PlasmaComponents.ToolButton {
+								text: i18n("Back to ChatGPT")
+								visible: !gptWebView.url.toString().match(/chat\.openai\.com\/(|chat|auth)/);
+								enabled: visible
+								icon.name: "draw-arrow-back"
+								display: PlasmaComponents.ToolButton.IconOnly
+								PlasmaComponents.ToolTip.text: text
+								PlasmaComponents.ToolTip.delay: Kirigami.Units.toolTipDelay
+								PlasmaComponents.ToolTip.visible: hovered
+								onClicked: gptWebView.url = "https://chat.openai.com/chat";
+							}
+
+							Kirigami.Heading {
+								id: titleText
+								Layout.alignment: Qt.AlignCenter
+								Layout.fillWidth: true
+								verticalAlignment: Text.AlignVCenter
+								text: i18n("ChatGPT")
+								color: theme.textColor
+							}
+						}
+
+						PlasmaComponents.ToolButton {
+							text: i18n("Debug")
+							checkable: true
+							checked: gptWebViewInspector.enabled
+							visible: Qt.application.arguments[0] == "plasmoidviewer" || plasmoid.configuration.debugConsole
+							enabled: visible
+							icon.name: "format-text-code"
+							display: PlasmaComponents.ToolButton.IconOnly
+							PlasmaComponents.ToolTip.text: text
+							PlasmaComponents.ToolTip.delay: Kirigami.Units.toolTipDelay
+							PlasmaComponents.ToolTip.visible: hovered
+							onToggled: {
+								gptWebViewInspector.visible = !gptWebViewInspector.visible;
+								gptWebViewInspector.enabled = visible || gptWebViewInspector.visible
+							}
+						}
+
+						PlasmaComponents.ToolButton {
+							id: proButton
+							checkable: true
+							checked: proLinkContainer.visible
+							text: i18n("Im a Pro")
+							visible: gptWebView.url.toString().match(/chat\.openai\.com\/auth/);
+							icon.name: "x-office-contact"
+							display: PlasmaComponents.ToolButton.IconOnly
+							PlasmaComponents.ToolTip.text: text
+							PlasmaComponents.ToolTip.delay: Kirigami.Units.toolTipDelay
+							PlasmaComponents.ToolTip.visible: hovered
+							onToggled: proLinkContainer.visible = !proLinkContainer.visible;
+						}
+
+						PlasmaComponents.ToolButton {
+							id: refreshButton
+							text: i18n("Reload")
+							icon.name: "view-refresh"
+							display: PlasmaComponents.ToolButton.IconOnly
+							PlasmaComponents.ToolTip.text: text
+							PlasmaComponents.ToolTip.delay: Kirigami.Units.toolTipDelay
+							PlasmaComponents.ToolTip.visible: hovered
+							onClicked: gptWebView.reload();
+						}
+
+						PlasmaComponents.ToolButton {
+							id: pinButton
+							checkable: true
+							checked: plasmoid.configuration.pin
+							icon.name: "window-pin"
+							text: i18n("Keep Open")
+							display: PlasmaComponents.ToolButton.IconOnly
+							PlasmaComponents.ToolTip.text: text
+							PlasmaComponents.ToolTip.delay: Kirigami.Units.toolTipDelay
+							PlasmaComponents.ToolTip.visible: hovered
+							onToggled: plasmoid.configuration.pin = checked
+						}
+					}
+
+					RowLayout {
+						id: proLinkContainer
+						Layout.fillWidth: true
+						visible: false;
+
+						PlasmaComponents.TextField {
+							id: proLinkField
+
+							enabled: proLinkContainer.visible
+							Layout.fillWidth: true
+
+							placeholderText: i18n("Paste the accesss link that was send to your email.")
+							text: ""
+						}
+
+						PlasmaComponents.Button {
+							enabled: proLinkContainer.visible
+							icon.name: "go-next"
+							onClicked:  {
+								gptWebView.url = proLinkField.text;
+								proLinkContainer.visible= false;
+							}
+						}
 					}
 				}
-				Text {
-					id:titleText
-					Layout.alignment:Qt.AlignCenter
-					Layout.fillWidth:true
-					height:parent.height
-					verticalAlignment:Text.AlignVCenter
-					text:i18n("Chat-GPT")
-					color:theme.textColor
-				}
 			}
-			Button {
-				id:pinButton
-				height:24 * PlasmaCore.Units.devicePixelRatio
-				width:height
-				anchors {
-					right: parent.right;
-					top:parent.top;
-				}
-				checkable: true
-				icon.name: "window-pin"
-				checked: plasmoid.configuration.pin
-				onCheckedChanged: plasmoid.configuration.pin = checked
-			}
+
 			//-------------------- Connections  -----------------------
 			Binding {
 				target: plasmoid
@@ -145,159 +225,160 @@ Item {
 				value: !plasmoid.configuration.pin
 			}
 		}
+
 		FocusScope {
-			Layout.fillHeight:true
-			Layout.fillWidth:true
+			Layout.fillHeight: true
+			Layout.fillWidth: true
+
 			WebEngineView {
-				id:gptWebView
-				anchors.fill:parent
+				anchors.fill: parent
 
+				id: gptWebView
 				focus: true
-
-				url:"https://chat.openai.com/chat"
+				url: "https://chat.openai.com/chat"
 
 				profile: WebEngineProfile {
-					id:chatGptProfile
+					id: chatGptProfile
 					storageName: "chat-gpt"
-					offTheRecord:false
-					//persistentStoragePath:"~/.local/share/plasmashell/QtWebEngine/ChatGPT/"
+					offTheRecord: false
 					httpCacheType: WebEngineProfile.DiskHttpCache
-					persistentCookiesPolicy:WebEngineProfile.ForcePersistentCookies
+					persistentCookiesPolicy: WebEngineProfile.ForcePersistentCookies
 					userScripts: [
 						WebEngineScript {
-							injectionPoint:WebEngineScript.DocumentCreation
-							name:"helperFunctions"
-							worldId:WebEngineScript.MainWorld
-							sourceUrl:"./js/helper_functions.js"
+							injectionPoint: WebEngineScript.DocumentCreation
+							name: "helperFunctions"
+							worldId: WebEngineScript.MainWorld
+							sourceUrl: "./js/helper_functions.js"
 						}
 					]
 				}
 
 				settings.javascriptCanAccessClipboard: plasmoid.configuration.allowClipboardAccess
 
-				onLoadingChanged:  {
+				onLoadingChanged: {
 					if(WebEngineView.LoadSucceededStatus === loadRequest.status) {
 						root.reloadRetries = 0;
-						var themeLightness = (isDark(theme.backgroundColor) ? 'dark' : 'light') ;
+						let themeLightness = (isDark(theme.backgroundColor) ? 'dark' : 'light') ;
+
 						gptWebView.runJavaScript("document.userScripts.setConfig("+JSON.stringify(plasmoid.configuration)+");");
 						gptWebView.runJavaScript("document.userScripts.setSendOnEnter();");
 						gptWebView.runJavaScript("document.userScripts.getTheme();",function(theme) {
-							console.log("GetTheme run :" + theme);
 							if( !plasmoid.expanded && plasmoid.configuration.matchTheme && (!theme ||  theme !== themeLightness)) {
 								gptWebView.runJavaScript("document.userScripts.setTheme('"+themeLightness+"');");
 								gptWebView.relreloadAndBypassCacheoad();
-							} else  if(plasmoid.configuration.matchTheme && theme !== themeLightness) {
+							} else if(plasmoid.configuration.matchTheme && theme !== themeLightness) {
 								root.themeMismatch = true;
 							}
 						});
 						gptWebView.runJavaScript("document.userScripts.setTheme('"+themeLightness+"');");
-
-					} else if(WebEngineView.LoadFailedStatus === loadRequest.status &&
+					} else if(
+						WebEngineView.LoadFailedStatus === loadRequest.status &&
 						!plasmoid.expanded &&
-						Date.now() > root.nextReloadTime && root.reloadRetries < 10) {
-						console.log("Failed  when loading  page, reloading as  we are hidden..");
-					gptWebView.reload();
-					root.reloadRetries +=1;
-					root.nextReloadTime = Date.now() + 1000*(2**root.reloadRetries);
-						}
+						Date.now() > root.nextReloadTime && root.reloadRetries < 10
+					) {
+						console.log("Failed  when loading  page, reloading as we are hidden..");
+						gptWebView.reload();
+						root.reloadRetries +=1;
+						root.nextReloadTime = Date.now() + 1000 * (2**root.reloadRetries);
+					}
 				}
 
-				onJavaScriptConsoleMessage : if (Qt.application.arguments[0] == "plasmoidviewer") {
-					console.log("Chat-GPT : " + message);
+				onJavaScriptConsoleMessage: if(Qt.application.arguments[0] == "plasmoidviewer") {
+					console.log("Chat-GPT: " + message);
 				}
 
-				onNavigationRequested :if(request.navigationType == WebEngineNavigationRequest.LinkClickedNavigation){
+				onNavigationRequested: if(request.navigationType == WebEngineNavigationRequest.LinkClickedNavigation) {
 					if(request.url.toString().match(/https?\:\/\/chat\.openai\.com/)) {
 						gptWebView.url = request.url;
 					} else {
 						Qt.openUrlExternally(request.url);
 						request.action = WebEngineNavigationRequest.IgnoreRequest;
 					}
-				} else {
-					console.log(request.url)
 				}
 
 				function isDark(color) {
-					var luminance = 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;
+					let luminance = 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;
 					return (luminance < 0.5);
 				}
 			}
 		}
-		WebEngineView {
-			id:gptWebViewInspector
-			enabled: false
-			visible: false
-			z:100
-			height:parent.height /2
 
-			Layout.fillWidth:true
-			Layout.alignment:Qt.AlignBottom
-			inspectedView:enabled ? gptWebView : null
-		}
-		Row {
-			id:proLinkContainer
-			Layout.fillWidth:true
-			visible:false;
-			TextField {
-				id:proLinkField
+		// WebEngineView {
+		// 	Layout.fillWidth: true
+		// 	Layout.alignment: Qt.AlignBottom
+			
+		// 	id: gptWebViewInspector
+		// 	enabled: false
+		// 	visible: false
+		// 	z: 100
+		// 	height: parent.height /2
+		// 	inspectedView: enabled ? gptWebView : null
+		// }
 
-				enabled: proLinkContainer.visible
-				Layout.fillWidth:true
+		// Row {
+		// 	id:proLinkContainer
+		// 	Layout.fillWidth:true
+		// 	visible:false;
+		// 	TextField {
+		// 		id:proLinkField
 
-				placeholderText:i18n("Paste the accesss link that was send to your email.")
-				text:""
-			}
-			Button {
-				// text: i18n("ChatGPT Pro")
-				enabled: proLinkContainer.visible
-				icon.name: "go-next"
-				onClicked:  {
-					gptWebView.url = proLinkField.text;
-					proLinkContainer.visible= false;
-				}
-			}
-		}
-		Row {
-			id:toolRow
-			Layout.alignment:Qt.AlignBottom
-			height:24 * PlasmaCore.Units.devicePixelRatio
-			spacing: 5 *  PlasmaCore.Units.devicePixelRatio
-			Button {
-				text: i18n("Reload")
-				icon.name: "view-refresh"
-				onClicked: gptWebView.reload();
-			}
-			Button {
-				text: i18n("Im a Pro")
-				visible:gptWebView.url.toString().match(/chat\.openai\.com\/auth/);
-				icon.name: "x-office-contact"
-				onClicked: proLinkContainer.visible = true;
-			}
-			Button {
-				text: i18n("Back to ChatGPT")
-				visible:!gptWebView.url.toString().match(/chat\.openai\.com\/(|chat|auth)/);
-				enabled:visible
-				icon.name: "edit-undo"
-				onClicked: gptWebView.url = "https://chat.openai.com/chat";
-			}
-			Button {
-				text: i18n("Debug")
-				visible: Qt.application.arguments[0] == "plasmoidviewer" || plasmoid.configuration.debugConsole
-				enabled:visible
-				icon.name: "view-refresh"
-				onClicked: {
-					gptWebViewInspector.visible = !gptWebViewInspector.visible;
-					gptWebViewInspector.enabled = visible || gptWebViewInspector.visible
-				}
-			}
-			// Button {
-			//     text: i18n("Speek to me")
-			//     icon.name:"microphone-sensitivity-high"
-			//      onClicked: {
-			//          console.log(chatGptProfile.persistentStoragePath)
-			//      }
-			// }
-		}
+		// 		enabled: proLinkContainer.visible
+		// 		Layout.fillWidth:true
+
+		// 		placeholderText:i18n("Paste the accesss link that was send to your email.")
+		// 		text:""
+		// 	}
+		// 	Button {
+		// 		// text: i18n("ChatGPT Pro")
+		// 		enabled: proLinkContainer.visible
+		// 		icon.name: "go-next"
+		// 		onClicked:  {
+		// 			gptWebView.url = proLinkField.text;
+		// 			proLinkContainer.visible= false;
+		// 		}
+		// 	}
+		// }
+
+		// Row {
+		// 	id:toolRow
+		// 	Layout.alignment:Qt.AlignBottom
+		// 	height:24 * PlasmaCore.Units.devicePixelRatio
+		// 	spacing: 5 *  PlasmaCore.Units.devicePixelRatio
+
+		// 	// Button {
+		// 	// 	text: i18n("Im a Pro")
+		// 	// 	visible:gptWebView.url.toString().match(/chat\.openai\.com\/auth/);
+		// 	// 	icon.name: "x-office-contact"
+		// 	// 	onClicked: proLinkContainer.visible = true;
+		// 	// }
+
+		// 	Button {
+		// 		text: i18n("Back to ChatGPT")
+		// 		visible:!gptWebView.url.toString().match(/chat\.openai\.com\/(|chat|auth)/);
+		// 		enabled:visible
+		// 		icon.name: "edit-undo"
+		// 		onClicked: gptWebView.url = "https://chat.openai.com/chat";
+		// 	}
+			
+		// 	// Button {
+		// 	// 	text: i18n("Debug")
+		// 	// 	visible: Qt.application.arguments[0] == "plasmoidviewer" || plasmoid.configuration.debugConsole
+		// 	// 	enabled:visible
+		// 	// 	icon.name: "view-refresh"
+		// 	// 	onClicked: {
+		// 	// 		gptWebViewInspector.visible = !gptWebViewInspector.visible;
+		// 	// 		gptWebViewInspector.enabled = visible || gptWebViewInspector.visible
+		// 	// 	}
+		// 	// }
+
+		// 	// Button {
+		// 	//     text: i18n("Speek to me")
+		// 	//     icon.name:"microphone-sensitivity-high"
+		// 	//      onClicked: {
+		// 	//          console.log(chatGptProfile.persistentStoragePath)
+		// 	//      }
+		// 	// }
+		// }
 	}
 
 }


### PR DESCRIPTION
Would be good to use Plasma and Kirigami components and follow some of the recommended guideline.
With these changes we'll have only one header with the buttons there, like we have in the default Plasma widgets.

![image](https://github.com/dark-eye/com.darkeye.chatGPT/assets/33737137/8caeef82-35cf-4d76-8bc9-a66e6c9889fe)

![image](https://github.com/dark-eye/com.darkeye.chatGPT/assets/33737137/7f283422-4a5b-4268-b94d-7af1c917b952)
